### PR TITLE
DOGEngine: add necessary files for building on Linux.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -451,3 +451,9 @@ vcpkg-manifest-install.log
 vcpkg_installed/
 
 # End of https://www.toptal.com/developers/gitignore/api/vcpkg
+
+# Custom .gitignore entries (mainly for Linux/CMake):
+
+my_overlays/
+my_build.sh
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.14) # Ensure compatibility with CMake 3.14 or later
+
+project(dog-engine LANGUAGES CXX)
+
+# Specify the C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Show all commands
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+# Find packages required for the project
+find_package(cereal CONFIG REQUIRED)
+find_package(EnTT CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
+find_package(OpenGL REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(glfw3 CONFIG REQUIRED)
+find_package(glm CONFIG REQUIRED)
+find_package(SDL2 CONFIG REQUIRED)
+find_package(imgui CONFIG REQUIRED)
+find_package(SDL2_image CONFIG REQUIRED)
+find_package(SDL2_mixer CONFIG REQUIRED)
+
+# Include the SDL2 bindings and OpenGL3 bindings for ImGui as specified in the dependencies
+# This assumes that the imgui package has been set up with the sdl2-binding, opengl3-binding, and sdl2-renderer-binding features enabled through vcpkg or other package management systems.
+
+# Main executable
+add_executable(dog-engine
+  DOGEngine/DOGEngine.cpp
+)
+
+# Add subdirectories for each component of the project
+add_subdirectory(DOGEngine/Client)
+add_subdirectory(DOGEngine/Core)
+add_subdirectory(DOGEngine/Editor)
+add_subdirectory(DOGEngine/Server)
+
+# TODO: Use target platform instead, who knows, maybe someone
+# is trying to cross-compile DOGEngine...
+
+if(WIN32)
+  add_definitions(-DDOG_PLATFORM_WINDOWS)
+else()
+  add_definitions(-DDOG_PLATFORM_UNIX)
+endif()
+
+# Link libraries with the main executable
+target_link_libraries(dog-engine
+  PRIVATE cereal::cereal
+  PRIVATE EnTT::EnTT
+  PRIVATE fmt::fmt # If using header-only, replace fmt::fmt with fmt::fmt-header-only
+  PRIVATE ${OPENGL_LIBRARIES}
+  PRIVATE GLEW::GLEW
+  PRIVATE glfw
+  PRIVATE glm::glm # If using header-only, replace glm::glm with glm::glm-header-only
+  PRIVATE SDL2::SDL2 SDL2::SDL2main # SDL2 static or dynamic as available
+  PRIVATE imgui::imgui
+  # PRIVATE SDL2_image::SDL2_image # SDL2_image static or dynamic as available, with libjpeg-turbo feature
+  PRIVATE SDL2_mixer::SDL2_mixer # SDL2_mixer static or dynamic as available, with mpg123 feature
+)
+
+# Include directories
+target_include_directories(dog-engine PRIVATE ${OPENGL_INCLUDE_DIR})

--- a/DOGEngine/Client/CMakeLists.txt
+++ b/DOGEngine/Client/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(dog-engine
+  PRIVATE GameClient.cpp
+)

--- a/DOGEngine/Core/CMakeLists.txt
+++ b/DOGEngine/Core/CMakeLists.txt
@@ -1,0 +1,8 @@
+target_sources(dog-engine
+  PRIVATE GameEntity.cpp
+  PRIVATE GamePlayer.cpp
+  PRIVATE Logger.cpp
+  PRIVATE Networking.cpp
+  PRIVATE Raycaster.cpp
+  PRIVATE Renderer.cpp
+)

--- a/DOGEngine/Core/Logger.cpp
+++ b/DOGEngine/Core/Logger.cpp
@@ -7,15 +7,13 @@
 #include <fmt/core.h> // For basic formatting
 #include <fmt/format.h> // For more complex formatting, if needed
 
-
 Logger::Logger(const std::string& outputFile, bool debugEnabled)
     : debug(debugEnabled) {
     std::filesystem::path logFilePath = std::filesystem::current_path() / outputFile;
-    errno_t err = fopen_s(&file, logFilePath.string().c_str(), "a");
-    if (err != 0) {
-        // If opening the file fails, print to stderr and ensure the file pointer is null
+    file = fopen(logFilePath.string().c_str(), "a");
+    if (file == nullptr) {
+        // If opening the file fails, print to stderr
         fprintf(stderr, "Failed to open log file: %s\n", logFilePath.string().c_str());
-        file = nullptr;
     }
 }
 
@@ -33,10 +31,9 @@ void Logger::SetConfig(const std::string& outputFile, bool debugEnabled) {
 
     // Attempt to open the new log file
     std::filesystem::path logFilePath = std::filesystem::current_path() / outputFile;
-    errno_t err = fopen_s(&instance.file, logFilePath.string().c_str(), "a");
-    if (err != 0) {
+    instance.file = fopen(logFilePath.string().c_str(), "a");
+    if (instance.file == nullptr) {
         fprintf(stderr, "Failed to open log file: %s\n", logFilePath.string().c_str());
-        instance.file = nullptr;
     }
 }
 

--- a/DOGEngine/Editor/BuildSystem.unix.cpp
+++ b/DOGEngine/Editor/BuildSystem.unix.cpp
@@ -1,0 +1,18 @@
+// BuildSystem.unix.cpp
+#ifdef DOG_PLATFORM_UNIX
+#include "BuildSystem.h"
+
+BuildSystem::BuildSystem(const std::string& buildToolPath) : buildToolPath(buildToolPath) {
+    // TODO
+}
+
+bool BuildSystem::compile(const std::string& projectPath, const std::string& additionalArguments, bool launchInNewWindow, bool keepWindowOpen) {
+    // TODO
+    return true;
+}
+
+bool BuildSystem::checkBuildToolExists() {
+    // TODO
+    return true;
+}
+#endif

--- a/DOGEngine/Editor/BuildSystem.windows.cpp
+++ b/DOGEngine/Editor/BuildSystem.windows.cpp
@@ -1,4 +1,5 @@
-// BuildSystem.cpp
+// BuildSystem.windows.cpp
+#ifdef DOG_PLATFORM_WINDOWS
 #include "BuildSystem.h"
 #include <iostream>
 #include <windows.h>
@@ -79,3 +80,4 @@ bool BuildSystem::checkBuildToolExists() {
     return (dwAttrib != INVALID_FILE_ATTRIBUTES &&
         !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
 }
+#endif

--- a/DOGEngine/Editor/CMakeLists.txt
+++ b/DOGEngine/Editor/CMakeLists.txt
@@ -1,0 +1,5 @@
+target_sources(dog-engine
+  PRIVATE BuildSystem.windows.cpp
+  PRIVATE BuildSystem.unix.cpp
+  PRIVATE GameEditor.cpp
+)

--- a/DOGEngine/Server/CMakeLists.txt
+++ b/DOGEngine/Server/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(dog-engine
+  PRIVATE GameServer.cpp
+)


### PR DESCRIPTION
It now successfully builds with `cmake` and `vcpkg` on Linux, though some platform-specific source files are mostly placeholders.

It has been tested successfully in Devuan 5 with Wayland (though not having systemd made a custom build script for my setup necessary, which it is not included in the PR).